### PR TITLE
Refactor toasts to its own module

### DIFF
--- a/src/components/ToastDrawer/ToastDrawer.js
+++ b/src/components/ToastDrawer/ToastDrawer.js
@@ -4,7 +4,7 @@ import { Toast } from 'react-bootstrap';
 import React, { Component } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-import { getToasts } from 'selectors/application';
+import { getQueue } from 'selectors/toast';
 
 export class ToastDrawer extends Component {
   static propTypes = {
@@ -47,7 +47,7 @@ export class ToastDrawer extends Component {
 }
 
 const mapStateToProps = state => ({
-  toasts: getToasts(state)
+  toasts: getQueue(state)
 });
 
 export default connect(

--- a/src/components/ToastDrawer/ToastDrawer.test.js
+++ b/src/components/ToastDrawer/ToastDrawer.test.js
@@ -6,7 +6,7 @@ import configureStore from 'redux-mock-store';
 import ConnectedToastDrawer, { ToastDrawer } from './ToastDrawer';
 
 describe('<ToastDrawer />', () => {
-  const toasts = [
+  const queue = [
     {
       id: 'test',
       title: 'I am a toast',
@@ -15,7 +15,7 @@ describe('<ToastDrawer />', () => {
   ];
 
   it('renders correctly', () => {
-    const props = { toasts };
+    const props = { toasts: queue };
     const component = renderer.create(<ToastDrawer {...props} />);
 
     expect(component.toJSON()).toMatchSnapshot();
@@ -29,7 +29,7 @@ describe('<ToastDrawer />', () => {
   });
 
   it('renders connected component correctly', () => {
-    const initialState = { application: { toasts } };
+    const initialState = { toast: { queue } };
     const mockStore = configureStore();
     const store = mockStore(initialState);
     const component = renderer.create(

--- a/src/reducers/application.js
+++ b/src/reducers/application.js
@@ -3,10 +3,6 @@ import { buildActions } from 'utils';
 export const types = buildActions('application', [
   'INIT_APP',
   'LOGIN_USER',
-  'POP_TOAST',
-  'ADD_TOAST',
-  'REMOVE_TOAST',
-  'HIDE_TOAST',
   'REQUEST_TOKEN',
   'REQUEST_TOKEN_SUCCESS',
   'REQUEST_TOKEN_FAILURE',
@@ -31,26 +27,6 @@ const loginUser = (emailAddress, password) => ({
   type: types.LOGIN_USER,
   emailAddress,
   password
-});
-
-const popToast = toast => ({
-  type: types.POP_TOAST,
-  toast
-});
-
-const addToast = toast => ({
-  type: types.ADD_TOAST,
-  toast
-});
-
-const removeToast = id => ({
-  type: types.REMOVE_TOAST,
-  id
-});
-
-const hideToast = id => ({
-  type: types.HIDE_TOAST,
-  id
 });
 
 const requestToken = (emailAddress, password) => ({
@@ -123,10 +99,6 @@ const registerUserFailure = error => ({
 export const actions = {
   initApp,
   loginUser,
-  popToast,
-  addToast,
-  removeToast,
-  hideToast,
   requestToken,
   requestTokenSuccess,
   requestTokenFailure,
@@ -157,42 +129,11 @@ export const initialState = {
     registering: false,
     complete: false,
     error: null
-  },
-  toasts: []
+  }
 };
 
 export const reducer = (state = initialState, action = {}) => {
   switch (action.type) {
-    case types.ADD_TOAST:
-      return {
-        ...state,
-        toasts: [...state.toasts, action.toast]
-      };
-    case types.REMOVE_TOAST:
-      return {
-        ...state,
-        toasts: state.toasts.filter(toast => toast.id !== action.id)
-      };
-    case types.HIDE_TOAST: {
-      const originalToast = state.toasts.find(toast => toast.id === action.id);
-
-      if (!originalToast) {
-        return state;
-      }
-
-      const newToast = {
-        ...originalToast,
-        show: false
-      };
-      const filteredToasts = state.toasts.filter(
-        toast => toast.id !== action.id
-      );
-
-      return {
-        ...state,
-        toasts: [...filteredToasts, newToast]
-      };
-    }
     case types.LOGIN_USER:
       return {
         ...state,

--- a/src/reducers/application.test.js
+++ b/src/reducers/application.test.js
@@ -8,12 +8,6 @@ describe('application reducer', () => {
   const token = 'testing';
   const expiration = dayjs();
   const error = { message: 'Failed' };
-  const toast = {
-    id: 'test123',
-    title: 'Testing',
-    icon: 'heart',
-    message: 'This is a test.'
-  };
 
   it('has INIT_APP action', () => {
     expect(actions.initApp()).toEqual({
@@ -251,72 +245,6 @@ describe('application reducer', () => {
 
     expect(reducer({}, action)).toEqual({
       registration: { registering: false, complete: true, error }
-    });
-  });
-
-  it('has POP_TOAST action', () => {
-    const action = actions.popToast(toast);
-
-    expect(action).toEqual({
-      type: types.POP_TOAST,
-      toast
-    });
-  });
-
-  it('has ADD_TOAST action', () => {
-    const action = actions.addToast(toast);
-
-    expect(action).toEqual({
-      type: types.ADD_TOAST,
-      toast
-    });
-  });
-
-  it('reduces ADD_TOAST action', () => {
-    const action = actions.addToast(toast);
-
-    expect(reducer({ toasts: [] }, action)).toEqual({
-      toasts: [toast]
-    });
-  });
-
-  it('has REMOVE_TOAST action', () => {
-    const { id } = toast;
-    const action = actions.removeToast(id);
-
-    expect(action).toEqual({
-      type: types.REMOVE_TOAST,
-      id
-    });
-  });
-
-  it('reduces REMOVE_TOAST action', () => {
-    const action = actions.removeToast(toast.id);
-
-    expect(reducer({ toasts: [toast] }, action)).toEqual({
-      toasts: []
-    });
-  });
-
-  it('has HIDE_TOAST action', () => {
-    const { id } = toast;
-    const action = actions.hideToast(id);
-
-    expect(action).toEqual({
-      type: types.HIDE_TOAST,
-      id
-    });
-  });
-
-  it('reduces HIDE_TOAST action', () => {
-    const action = actions.hideToast(toast.id);
-
-    expect(reducer({ toasts: [toast] }, action)).toEqual({
-      toasts: [{ ...toast, show: false }]
-    });
-
-    expect(reducer({ toasts: [] }, action)).toEqual({
-      toasts: []
     });
   });
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -4,11 +4,14 @@ import {
   reducer as application,
   initialState as applicationState
 } from './application';
+import { reducer as toast, initialState as toastState } from './toast';
 
 export const initialState = {
-  application: applicationState
+  application: applicationState,
+  toast: toastState
 };
 
 export default combineReducers({
-  application
+  application,
+  toast
 });

--- a/src/reducers/toast.js
+++ b/src/reducers/toast.js
@@ -1,0 +1,76 @@
+import { buildActions } from 'utils';
+
+export const types = buildActions('toast', [
+  'POP_TOAST',
+  'ADD_TOAST',
+  'REMOVE_TOAST',
+  'HIDE_TOAST'
+]);
+
+const popToast = toast => ({
+  type: types.POP_TOAST,
+  toast
+});
+
+const addToast = toast => ({
+  type: types.ADD_TOAST,
+  toast
+});
+
+const removeToast = id => ({
+  type: types.REMOVE_TOAST,
+  id
+});
+
+const hideToast = id => ({
+  type: types.HIDE_TOAST,
+  id
+});
+
+export const actions = {
+  popToast,
+  addToast,
+  removeToast,
+  hideToast
+};
+
+export const initialState = {
+  queue: []
+};
+
+export const reducer = (state = initialState, action = {}) => {
+  switch (action.type) {
+    case types.ADD_TOAST:
+      return {
+        ...state,
+        queue: [...state.queue, action.toast]
+      };
+    case types.REMOVE_TOAST:
+      return {
+        ...state,
+        queue: state.queue.filter(toast => toast.id !== action.id)
+      };
+    case types.HIDE_TOAST: {
+      const originalToast = state.queue.find(toast => toast.id === action.id);
+
+      if (!originalToast) {
+        return state;
+      }
+
+      const newToast = {
+        ...originalToast,
+        show: false
+      };
+      const filteredToasts = state.queue.filter(
+        toast => toast.id !== action.id
+      );
+
+      return {
+        ...state,
+        queue: [...filteredToasts, newToast]
+      };
+    }
+    default:
+      return state;
+  }
+};

--- a/src/reducers/toast.test.js
+++ b/src/reducers/toast.test.js
@@ -1,0 +1,76 @@
+import { actions, types, reducer } from './toast';
+
+describe('toast reducer', () => {
+  const toast = {
+    id: 'test123',
+    title: 'Testing',
+    icon: 'heart',
+    message: 'This is a test.'
+  };
+
+  it('has POP_TOAST action', () => {
+    const action = actions.popToast(toast);
+
+    expect(action).toEqual({
+      type: types.POP_TOAST,
+      toast
+    });
+  });
+
+  it('has ADD_TOAST action', () => {
+    const action = actions.addToast(toast);
+
+    expect(action).toEqual({
+      type: types.ADD_TOAST,
+      toast
+    });
+  });
+
+  it('reduces ADD_TOAST action', () => {
+    const action = actions.addToast(toast);
+
+    expect(reducer({ queue: [] }, action)).toEqual({
+      queue: [toast]
+    });
+  });
+
+  it('has REMOVE_TOAST action', () => {
+    const { id } = toast;
+    const action = actions.removeToast(id);
+
+    expect(action).toEqual({
+      type: types.REMOVE_TOAST,
+      id
+    });
+  });
+
+  it('reduces REMOVE_TOAST action', () => {
+    const action = actions.removeToast(toast.id);
+
+    expect(reducer({ queue: [toast] }, action)).toEqual({
+      queue: []
+    });
+  });
+
+  it('has HIDE_TOAST action', () => {
+    const { id } = toast;
+    const action = actions.hideToast(id);
+
+    expect(action).toEqual({
+      type: types.HIDE_TOAST,
+      id
+    });
+  });
+
+  it('reduces HIDE_TOAST action', () => {
+    const action = actions.hideToast(toast.id);
+
+    expect(reducer({ queue: [toast] }, action)).toEqual({
+      queue: [{ ...toast, show: false }]
+    });
+
+    expect(reducer({ queue: [] }, action)).toEqual({
+      queue: []
+    });
+  });
+});

--- a/src/sagas/application.js
+++ b/src/sagas/application.js
@@ -1,19 +1,10 @@
 import dayjs from 'dayjs';
-import nanoid from 'nanoid';
-import {
-  all,
-  call,
-  put,
-  takeLatest,
-  delay,
-  take,
-  takeEvery,
-  select
-} from 'redux-saga/effects';
+import { all, call, put, takeLatest, take, select } from 'redux-saga/effects';
 
 import request from 'utils/request';
-import { isLoggedIn, getUser } from 'selectors/application';
 import { actions, types } from 'reducers/application';
+import { actions as toastActions } from 'reducers/toast';
+import { isLoggedIn, getUser } from 'selectors/application';
 
 // snake_cased variables here come from RFC 6749
 /* eslint-disable camelcase */
@@ -57,7 +48,7 @@ function* requestTokenWorker({ emailAddress, password }) {
 
     yield put(actions.requestTokenFailure(error));
     yield put(
-      actions.popToast({
+      toastActions.popToast({
         title: 'Error!',
         icon: 'times-circle',
         message
@@ -92,7 +83,7 @@ function* requestCurrentUserWorker() {
 
     yield put(actions.requestCurrentUserFailure(error));
     yield put(
-      actions.popToast({
+      toastActions.popToast({
         title: 'Error',
         icon: 'times-circle',
         message
@@ -130,7 +121,7 @@ function* loginUserWorker({ emailAddress, password }) {
     }
 
     yield put(
-      actions.popToast({
+      toastActions.popToast({
         title: 'Logged in',
         icon: 'check',
         message: 'You have been authenticated.'
@@ -163,28 +154,13 @@ function* loginUserWorker({ emailAddress, password }) {
 
     yield put(actions.loginUserFailure(error));
     yield put(
-      actions.popToast({
+      toastActions.popToast({
         title: 'Error',
         icon: 'times-circle',
         message
       })
     );
   }
-}
-
-function* popToastWorker({ toast }) {
-  // ensure there is a unique key for each toast
-  const id = toast.id || nanoid();
-
-  toast.id = id;
-  toast.show = true;
-
-  yield put(actions.addToast(toast));
-  yield delay(toast.interval || 5000);
-  yield put(actions.hideToast(id));
-  // this is the default Fade transition time
-  yield delay(500);
-  yield put(actions.removeToast(id));
 }
 
 function* registerUserWorker({
@@ -205,7 +181,7 @@ function* registerUserWorker({
     if (result.success) {
       yield put(actions.registerUserSuccess());
       yield put(
-        actions.popToast({
+        toastActions.popToast({
           title: 'Success!',
           icon: 'check',
           message: 'Check your email for an activation link.'
@@ -219,7 +195,7 @@ function* registerUserWorker({
 
     yield put(actions.registerUserFailure(error));
     yield put(
-      actions.popToast({
+      toastActions.popToast({
         title: 'Error',
         icon: 'times-circle',
         message
@@ -230,10 +206,6 @@ function* registerUserWorker({
 
 function* loginUserWatcher() {
   yield takeLatest(types.LOGIN_USER, loginUserWorker);
-}
-
-function* popToastWatcher() {
-  yield takeEvery(types.POP_TOAST, popToastWorker);
 }
 
 function* requestTokenWatcher() {
@@ -250,7 +222,6 @@ function* registerUserWatcher() {
 
 export const workers = {
   loginUserWorker,
-  popToastWorker,
   registerUserWorker,
   requestTokenWorker,
   requestCurrentUserWorker
@@ -258,7 +229,6 @@ export const workers = {
 
 export const watchers = {
   loginUserWatcher,
-  popToastWatcher,
   registerUserWatcher,
   requestTokenWatcher,
   requestCurrentUserWatcher

--- a/src/sagas/application.test.js
+++ b/src/sagas/application.test.js
@@ -1,13 +1,12 @@
 import dayjs from 'dayjs';
 import MockDate from 'mockdate';
-import { all, put, call, take, select, delay } from 'redux-saga/effects';
+import { all, put, call, take, select } from 'redux-saga/effects';
 
 import request from 'utils/request';
-import { isLoggedIn, getUser } from 'selectors/application';
 import { actions, types } from 'reducers/application';
+import { actions as toastActions } from 'reducers/toast';
 import appSaga, { watchers, workers } from './application';
-
-jest.mock('nanoid', () => () => 'testing');
+import { isLoggedIn, getUser } from 'selectors/application';
 
 /* eslint-disable camelcase */
 describe('application sagas', () => {
@@ -92,7 +91,7 @@ describe('application sagas', () => {
 
     expect(result.value).toEqual(
       put(
-        actions.popToast({
+        toastActions.popToast({
           title: 'Error!',
           icon: 'times-circle',
           message: error.message
@@ -200,7 +199,7 @@ describe('application sagas', () => {
 
     expect(result.value).toEqual(
       put(
-        actions.popToast({
+        toastActions.popToast({
           title: 'Error',
           icon: 'times-circle',
           message
@@ -248,7 +247,7 @@ describe('application sagas', () => {
 
     expect(result.value).toEqual(
       put(
-        actions.popToast({
+        toastActions.popToast({
           title: 'Logged in',
           icon: 'check',
           message: 'You have been authenticated.'
@@ -291,7 +290,7 @@ describe('application sagas', () => {
 
     expect(result.value).toEqual(
       put(
-        actions.popToast({
+        toastActions.popToast({
           title: 'Logged in',
           icon: 'check',
           message: 'You have been authenticated.'
@@ -342,7 +341,7 @@ describe('application sagas', () => {
 
     expect(result.value).toEqual(
       put(
-        actions.popToast({
+        toastActions.popToast({
           title: 'Logged in',
           icon: 'check',
           message: 'You have been authenticated.'
@@ -375,48 +374,13 @@ describe('application sagas', () => {
 
     expect(result.value).toEqual(
       put(
-        actions.popToast({
+        toastActions.popToast({
           title: 'Error',
           icon: 'times-circle',
           message
         })
       )
     );
-  });
-
-  it('runs popToastWorker', () => {
-    const defaultInterval = 5000;
-    const toast = {
-      title: 'Test',
-      icon: 'heart',
-      message: 'Testing'
-    };
-    const modifiedToast = {
-      ...toast,
-      id: 'testing',
-      show: true
-    };
-    const gen = workers.popToastWorker({ toast });
-
-    let result = gen.next();
-
-    expect(result.value).toEqual(put(actions.addToast(modifiedToast)));
-
-    result = gen.next();
-
-    expect(result.value).toEqual(delay(defaultInterval));
-
-    result = gen.next();
-
-    expect(result.value).toEqual(put(actions.hideToast(modifiedToast.id)));
-
-    result = gen.next();
-
-    expect(result.value).toEqual(delay(500));
-
-    result = gen.next();
-
-    expect(result.value).toEqual(put(actions.removeToast(modifiedToast.id)));
   });
 
   it('forks all watchers', () => {

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -1,7 +1,8 @@
-import { fork } from 'redux-saga/effects';
+import { all, fork } from 'redux-saga/effects';
 
 import application from './application';
+import toast from './toast';
 
 export default function* saga() {
-  yield fork(application);
+  yield all([application, toast].map(fork));
 }

--- a/src/sagas/index.test.js
+++ b/src/sagas/index.test.js
@@ -1,6 +1,7 @@
-import { fork } from 'redux-saga/effects';
+import { fork, all } from 'redux-saga/effects';
 
 import saga from './index';
+import toast from './toast';
 import application from './application';
 
 describe('index saga', () => {
@@ -8,6 +9,6 @@ describe('index saga', () => {
     const gen = saga();
     const result = gen.next();
 
-    expect(result.value).toEqual(fork(application));
+    expect(result.value).toEqual(all([application, toast].map(fork)));
   });
 });

--- a/src/sagas/toast.js
+++ b/src/sagas/toast.js
@@ -1,0 +1,35 @@
+import nanoid from 'nanoid';
+import { put, delay, takeEvery, all } from 'redux-saga/effects';
+
+import { actions, types } from 'reducers/toast';
+
+function* popToastWorker({ toast }) {
+  // ensure there is a unique key for each toast
+  const id = toast.id || nanoid();
+
+  toast.id = id;
+  toast.show = true;
+
+  yield put(actions.addToast(toast));
+  yield delay(toast.interval || 5000);
+  yield put(actions.hideToast(id));
+  // this is the default Fade transition time
+  yield delay(500);
+  yield put(actions.removeToast(id));
+}
+
+function* popToastWatcher() {
+  yield takeEvery(types.POP_TOAST, popToastWorker);
+}
+
+export const workers = {
+  popToastWorker
+};
+
+export const watchers = {
+  popToastWatcher
+};
+
+export default function* saga() {
+  yield all(Object.values(watchers).map(watcher => watcher()));
+}

--- a/src/sagas/toast.test.js
+++ b/src/sagas/toast.test.js
@@ -1,0 +1,66 @@
+import { all, put, delay, takeEvery } from 'redux-saga/effects';
+
+import { actions, types } from 'reducers/toast';
+import toastSaga, { workers, watchers } from 'sagas/toast';
+
+jest.mock('nanoid', () => () => 'testing');
+
+describe('toast sagas', () => {
+  it('runs popToastWorker', () => {
+    const defaultInterval = 5000;
+    const toast = {
+      title: 'Test',
+      icon: 'heart',
+      message: 'Testing'
+    };
+    const modifiedToast = {
+      ...toast,
+      id: 'testing',
+      show: true
+    };
+    const gen = workers.popToastWorker({ toast });
+
+    let result = gen.next();
+
+    expect(result.value).toEqual(put(actions.addToast(modifiedToast)));
+
+    result = gen.next();
+
+    expect(result.value).toEqual(delay(defaultInterval));
+
+    result = gen.next();
+
+    expect(result.value).toEqual(put(actions.hideToast(modifiedToast.id)));
+
+    result = gen.next();
+
+    expect(result.value).toEqual(delay(500));
+
+    result = gen.next();
+
+    expect(result.value).toEqual(put(actions.removeToast(modifiedToast.id)));
+  });
+
+  it('runs popToastWatcher', () => {
+    const gen = watchers.popToastWatcher();
+
+    let result = gen.next();
+
+    expect(result.value).toEqual(
+      takeEvery(types.POP_TOAST, workers.popToastWorker)
+    );
+
+    result = gen.next();
+
+    expect(result.done).toBeTruthy();
+  });
+
+  it('forks all watchers', () => {
+    const gen = toastSaga();
+    const result = gen.next();
+
+    expect(result.value).toEqual(
+      all(Object.values(watchers).map(watcher => watcher()))
+    );
+  });
+});

--- a/src/selectors/application.js
+++ b/src/selectors/application.js
@@ -52,8 +52,3 @@ export const isRegistering = createSelector(
   getRegistration,
   registration => registration.registering && !registration.complete
 );
-
-export const getToasts = createSelector(
-  getApplication,
-  application => application.toasts
-);

--- a/src/selectors/application.test.js
+++ b/src/selectors/application.test.js
@@ -11,17 +11,12 @@ import {
   getTokenExpiration,
   getRegistration,
   isRegistering,
-  getToasts,
   isLoggedIn
 } from './application';
 
 describe('application selectors', () => {
   const state = { application: initialState };
-  const {
-    authorization: authState,
-    registration: regState,
-    toasts
-  } = initialState;
+  const { authorization: authState, registration: regState } = initialState;
 
   it('can getApplication', () => {
     expect(getApplication(state)).toBe(state.application);
@@ -57,10 +52,6 @@ describe('application selectors', () => {
 
   it('can get isRegistering', () => {
     expect(isRegistering(state)).toBe(regState.registering);
-  });
-
-  it('can getToasts', () => {
-    expect(getToasts(state)).toBe(toasts);
   });
 
   describe('can get isLoggedIn', () => {

--- a/src/selectors/toast.js
+++ b/src/selectors/toast.js
@@ -1,0 +1,8 @@
+import { createSelector } from 'reselect';
+
+export const getToasts = state => state.toast;
+
+export const getQueue = createSelector(
+  getToasts,
+  toast => toast.queue
+);

--- a/src/selectors/toast.test.js
+++ b/src/selectors/toast.test.js
@@ -1,0 +1,15 @@
+import { getToasts, getQueue } from './toast';
+import { initialState } from 'reducers/toast';
+
+describe('toast selectors', () => {
+  const state = { toast: initialState };
+  const { queue } = initialState;
+
+  it('can getToasts', () => {
+    expect(getToasts(state)).toBe(initialState);
+  });
+
+  it('can getQueue', () => {
+    expect(getQueue(state)).toBe(queue);
+  });
+});


### PR DESCRIPTION
This PR makes the following changes:

* [Move](https://github.com/mixnjuice/frontend/pull/45/files#diff-bb7a6a61e449a99e756724ffa2c8c109L6) all toast related actions, types, workers, watchers, and selectors from the application module to a [new](https://github.com/mixnjuice/frontend/pull/45/files#diff-d6810643eca22046a8f827995788c213R3) **toast** module
* Modifies the state so that the `toasts` array is now called `queue`, full path `state.toast.queue`