### PR TITLE
Add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Gusta Project Frontend
 
+Build status: [![CircleCI](https://circleci.com/gh/mixnjuice/frontend/tree/master.svg?style=svg)](https://circleci.com/gh/mixnjuice/frontend/tree/master)
+Test coverage: [![codecov](https://codecov.io/gh/mixnjuice/frontend/branch/master/graph/badge.svg)](https://codecov.io/gh/mixnjuice/frontend)
+
 ## Usage
 
 After cloning the repository, run `npm install` to install the dependencies. From there, `npm run build` will create a production build of the application in `./dist`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Gusta Project Frontend
 
 Build status: [![CircleCI](https://circleci.com/gh/mixnjuice/frontend/tree/master.svg?style=svg)](https://circleci.com/gh/mixnjuice/frontend/tree/master)
+
 Test coverage: [![codecov](https://codecov.io/gh/mixnjuice/frontend/branch/master/graph/badge.svg)](https://codecov.io/gh/mixnjuice/frontend)
 
 ## Usage


### PR DESCRIPTION
This PR adds two badges to the README for display on the repo front page. One shows the latest CircleCI build status for master, the other shows the current latest codecov report.