### PR TITLE
Allow failure notifier to execute even if build failed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,5 +49,3 @@ workflows:
             - build
       - notify_failure:
           context: webhooks
-          requires:
-            - build


### PR DESCRIPTION
This PR removes the dependency from the notify_failure task to the build task. This was preventing the failure job from ever triggering, because if the build job fails its dependencies do not execute.