### PR TITLE
Add optional chaining support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,6 +11,7 @@
   ],
   "plugins": [
     "@babel/plugin-syntax-dynamic-import",
+    "@babel/plugin-proposal-optional-chaining",
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-object-rest-spread",
     [

--- a/package-lock.json
+++ b/package-lock.json
@@ -528,6 +528,16 @@
         "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
       }
     },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.7.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.7.5.tgz",
+      "integrity": "sha512-sOwFqT8JSchtJeDD+CjmWCaiFoLxY4Ps7NjvwHC/U7l4e9i5pTRNt8nDMIFSOUL+ncFbYSwruHM8WknYItWdXw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.7.4"
+      }
+    },
     "@babel/plugin-proposal-unicode-property-regex": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.6.2.tgz",
@@ -606,6 +616,15 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
       "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.7.4.tgz",
+      "integrity": "sha512-2MqYD5WjZSbJdUagnJvIdSfkb/ucOC9/1fRJxm7GAxY6YQLWlUvkfxoNbUPcPLHJyetKUDQ4+yyuUyAoc0HriA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@babel/core": "^7.6.4",
     "@babel/plugin-proposal-class-properties": "^7.5.5",
     "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
+    "@babel/plugin-proposal-optional-chaining": "^7.7.5",
     "@babel/plugin-transform-regenerator": "^7.4.5",
     "@babel/plugin-transform-runtime": "^7.6.2",
     "@babel/preset-env": "^7.6.3",

--- a/src/pages/Recipe.js
+++ b/src/pages/Recipe.js
@@ -86,7 +86,7 @@ export class Recipe extends Component {
   }
 
   findRecipe() {
-    const query = this.props.location.search;
+    const query = this.props.location?.search;
     const queryValues = queryString.parse(query);
     const pageId = parseFloat(queryValues.id);
 
@@ -122,11 +122,11 @@ export class Recipe extends Component {
   }
 
   compareWithStash() {
-    const query = this.props.location.search;
+    const query = this.props.location?.search;
     const queryValues = queryString.parse(query);
     const pageId = parseFloat(queryValues.id);
 
-    const recipe = recipes.filter(e => e.id === pageId)[0];
+    const recipe = recipes?.filter?.(e => e.id === pageId)[0];
 
     let index = 0;
 

--- a/src/reducers/toast.js
+++ b/src/reducers/toast.js
@@ -48,10 +48,12 @@ export const reducer = (state = initialState, action = {}) => {
     case types.REMOVE_TOAST:
       return {
         ...state,
-        queue: state.queue.filter(toast => toast.id !== action.id)
+        queue: state.queue?.filter?.(toast => toast.id !== action.id)
       };
     case types.HIDE_TOAST: {
-      const originalToast = state.queue.find(toast => toast.id === action.id);
+      const originalToast = state.queue?.find?.(
+        toast => toast.id === action.id
+      );
 
       if (!originalToast) {
         return state;
@@ -61,7 +63,7 @@ export const reducer = (state = initialState, action = {}) => {
         ...originalToast,
         show: false
       };
-      const filteredToasts = state.queue.filter(
+      const filteredToasts = state.queue?.filter?.(
         toast => toast.id !== action.id
       );
 


### PR DESCRIPTION
This PR adds support for statements like `foo?.bar` instead of `foo && foo.bar`. It also adds a few of these guards in places where props are not marked `.isRequired` or nested objects are accessed.