### PR TITLE
Fix Mattermost failure notifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,16 +25,8 @@ jobs:
       - run:
           name: test
           command: 'npm test && codecov'
-  notify_success:
-    docker:
-      - image: byrnedo/alpine-curl:latest
-    steps:
       - mattermost-notify/notify_on_success:
           webhook: '$MATTERMOST_WEBHOOK_FRONTEND'
-  notify_failure:
-    docker:
-      - image: byrnedo/alpine-curl:latest
-    steps:
       - mattermost-notify/notify_on_failure:
           webhook: '$MATTERMOST_WEBHOOK_FRONTEND'
 
@@ -42,10 +34,5 @@ workflows:
   version: 2
   main_workflow:
     jobs:
-      - build
-      - notify_success:
-          context: webhooks
-          requires:
-            - build
-      - notify_failure:
-          context: webhooks
+      - build:
+          context: builds

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -20,10 +20,6 @@ describe('utilities', () => {
     expect(buildActions(module, actions)).toEqual(result);
   });
 
-  it('fails', () => {
-    expect(true).toBe(false);
-  });
-
   describe('mockComponent', () => {
     it('exists', () => {
       expect(mockComponent).toBeInstanceOf(Function);

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -20,6 +20,10 @@ describe('utilities', () => {
     expect(buildActions(module, actions)).toEqual(result);
   });
 
+  it('fails', () => {
+    expect(true).toBe(false);
+  });
+
   describe('mockComponent', () => {
     it('exists', () => {
       expect(mockComponent).toBeInstanceOf(Function);


### PR DESCRIPTION
This PR fixes notifications to Mattermost about build failures. Currently, the setup does not work because the notify job only triggers if the previous job was successful. To resolve this, inline the notify steps in the build job, where their `when: on_fail` and `when: on_success` will now work as expected.