### PR TITLE
SplitSlider component

### DIFF
--- a/src/components/SplitSlider/SplitSlider.js
+++ b/src/components/SplitSlider/SplitSlider.js
@@ -7,10 +7,12 @@ export default class SplitSlider extends Component {
   static propTypes = {
     tickInterval: PropTypes.number.isRequired,
     leftLabel: PropTypes.string.isRequired,
-    rightLabel: PropTypes.string.isRequired
+    rightLabel: PropTypes.string.isRequired,
+    initialValue: PropTypes.number.isRequired
   };
 
   static defaultProps = {
+    value: 50,
     tickInterval: 5,
     leftLabel: 'VG',
     rightLabel: 'PG'
@@ -20,7 +22,7 @@ export default class SplitSlider extends Component {
     super(props);
 
     this.progressRef = React.createRef();
-    this.state = { value: 50, dragging: false };
+    this.state = { value: this.props.initialValue, dragging: false };
     this.emptyCanvas = document.createElement('canvas');
     this.handleDrag = this.handleDrag.bind(this);
     this.handleClick = this.handleClick.bind(this);

--- a/src/components/SplitSlider/SplitSlider.js
+++ b/src/components/SplitSlider/SplitSlider.js
@@ -130,6 +130,7 @@ export default class SplitSlider extends Component {
             onDragEnd={this.handleDragEnd}
             onDragStart={this.handleDragStart}
             onDragEnter={this.handleDragEnter}
+            onDragOver={event => event.preventDefault()}
           >
             <ProgressBar
               key={1}

--- a/src/components/SplitSlider/SplitSlider.js
+++ b/src/components/SplitSlider/SplitSlider.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { InputGroup, ProgressBar, FormControl } from 'react-bootstrap';
+import { InputGroup, ProgressBar, FormControl, Button } from 'react-bootstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 export default class SplitSlider extends Component {
   static propTypes = {
@@ -21,6 +22,7 @@ export default class SplitSlider extends Component {
     this.state = { value: 50 };
     this.progressRef = React.createRef();
     this.handleClick = this.handleClick.bind(this);
+    this.handleReset = this.handleReset.bind(this);
     this.handleChange = this.handleChange.bind(this);
   }
 
@@ -68,6 +70,12 @@ export default class SplitSlider extends Component {
     });
   }
 
+  handleReset() {
+    this.setState({
+      value: 50
+    });
+  }
+
   render() {
     const { leftLabel, rightLabel } = this.props;
 
@@ -99,6 +107,11 @@ export default class SplitSlider extends Component {
           value={this.rightValue}
           onChange={this.handleChange}
         />
+        <InputGroup.Append>
+          <Button onClick={this.handleReset}>
+            <FontAwesomeIcon icon="undo" size="sm" />
+          </Button>
+        </InputGroup.Append>
       </InputGroup>
     );
   }

--- a/src/components/SplitSlider/SplitSlider.js
+++ b/src/components/SplitSlider/SplitSlider.js
@@ -1,0 +1,81 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { InputGroup, ProgressBar, FormControl } from 'react-bootstrap';
+
+export default class SplitSlider extends Component {
+  static propTypes = {
+    tickInterval: PropTypes.number.isRequired,
+    leftLabel: PropTypes.string.isRequired,
+    rightLabel: PropTypes.string.isRequired
+  };
+
+  static defaultProps = {
+    tickInterval: 5,
+    leftLabel: 'PG',
+    rightLabel: 'VG'
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.handleChange = this.handleChange.bind(this);
+    this.state = { value: 50 };
+  }
+
+  get leftValue() {
+    return this.state.value;
+  }
+
+  get rightValue() {
+    return 100 - this.state.value;
+  }
+
+  handleChange(event) {
+    const {
+      target: { name, value }
+    } = event;
+
+    const intValue = parseInt(value, 10);
+
+    if (!intValue || intValue < 0 || intValue > 100) {
+      return;
+    }
+
+    this.setState({
+      value: name === 'left' ? intValue : Math.max(0, 100 - intValue)
+    });
+  }
+
+  render() {
+    const { leftLabel, rightLabel } = this.props;
+
+    return (
+      <InputGroup className="split-slider">
+        <ProgressBar>
+          <ProgressBar
+            key={1}
+            variant="warning"
+            label={leftLabel}
+            now={this.leftValue}
+          />
+          <ProgressBar
+            key={2}
+            variant="success"
+            label={rightLabel}
+            now={this.rightValue}
+          />
+        </ProgressBar>
+        <FormControl
+          name="left"
+          value={this.leftValue}
+          onChange={this.handleChange}
+        />
+        <FormControl
+          name="right"
+          value={this.rightValue}
+          onChange={this.handleChange}
+        />
+      </InputGroup>
+    );
+  }
+}

--- a/src/components/SplitSlider/SplitSlider.js
+++ b/src/components/SplitSlider/SplitSlider.js
@@ -8,7 +8,9 @@ export default class SplitSlider extends Component {
     tickInterval: PropTypes.number.isRequired,
     leftLabel: PropTypes.string.isRequired,
     rightLabel: PropTypes.string.isRequired,
-    initialValue: PropTypes.number.isRequired
+    initialValue: PropTypes.number.isRequired,
+    name: PropTypes.string.isRequired,
+    onChange: PropTypes.func.isRequired
   };
 
   static defaultProps = {
@@ -38,23 +40,31 @@ export default class SplitSlider extends Component {
   }
 
   get rightValue() {
-    return 100 - this.state.value;
+    return Math.max(0, 100 - this.state.value);
   }
 
   handleChange(event) {
     const {
-      target: { name, value }
+      target: { name: targetName, value: rawValue }
     } = event;
+    const { onChange, name } = this.props;
+    const { value: currentValue } = this.state;
 
-    const intValue = parseInt(value, 10);
+    const intValue = parseInt(rawValue, 10);
 
-    if (!intValue || intValue < 0 || intValue > 100) {
+    if (intValue === false || intValue < 0 || intValue > 100) {
       return;
     }
 
-    this.setState({
-      value: name === 'left' ? intValue : Math.max(0, 100 - intValue)
-    });
+    const value =
+      targetName === 'left' ? intValue : Math.max(0, 100 - intValue);
+
+    if (value !== currentValue) {
+      this.setState({ value });
+      onChange({
+        target: { name, value }
+      });
+    }
   }
 
   handleClick(event) {
@@ -67,12 +77,13 @@ export default class SplitSlider extends Component {
     } = event;
     const rect = progressRef.getBoundingClientRect();
     const percentage = ((screenX - rect.left) / rect.width) * 100;
-    const quantized = Math.ceil(percentage / tickInterval) * tickInterval;
+    const quantized = Math.round(percentage / tickInterval) * tickInterval;
+    const clamped = Math.min(100, Math.max(0, quantized));
 
     this.handleChange({
       target: {
         name: 'left',
-        value: quantized
+        value: clamped
       }
     });
   }

--- a/src/components/SplitSlider/SplitSlider.js
+++ b/src/components/SplitSlider/SplitSlider.js
@@ -11,8 +11,8 @@ export default class SplitSlider extends Component {
 
   static defaultProps = {
     tickInterval: 5,
-    leftLabel: 'PG',
-    rightLabel: 'VG'
+    leftLabel: 'VG',
+    rightLabel: 'PG'
   };
 
   constructor(props) {
@@ -77,13 +77,13 @@ export default class SplitSlider extends Component {
           <ProgressBar onClick={this.handleClick}>
             <ProgressBar
               key={1}
-              variant="warning"
+              variant="success"
               label={leftLabel}
               now={this.leftValue}
             />
             <ProgressBar
               key={2}
-              variant="success"
+              variant="warning"
               label={rightLabel}
               now={this.rightValue}
             />

--- a/src/components/SplitSlider/SplitSlider.js
+++ b/src/components/SplitSlider/SplitSlider.js
@@ -18,8 +18,10 @@ export default class SplitSlider extends Component {
   constructor(props) {
     super(props);
 
-    this.handleChange = this.handleChange.bind(this);
     this.state = { value: 50 };
+    this.progressRef = React.createRef();
+    this.handleClick = this.handleClick.bind(this);
+    this.handleChange = this.handleChange.bind(this);
   }
 
   get leftValue() {
@@ -46,25 +48,47 @@ export default class SplitSlider extends Component {
     });
   }
 
+  handleClick(event) {
+    const {
+      progressRef: { current: progressRef },
+      props: { tickInterval }
+    } = this;
+    const {
+      nativeEvent: { screenX }
+    } = event;
+    const rect = progressRef.getBoundingClientRect();
+    const percentage = ((screenX - rect.left) / rect.width) * 100;
+    const quantized = Math.ceil(percentage / tickInterval) * tickInterval;
+
+    this.handleChange({
+      target: {
+        name: 'left',
+        value: quantized
+      }
+    });
+  }
+
   render() {
     const { leftLabel, rightLabel } = this.props;
 
     return (
       <InputGroup className="split-slider">
-        <ProgressBar>
-          <ProgressBar
-            key={1}
-            variant="warning"
-            label={leftLabel}
-            now={this.leftValue}
-          />
-          <ProgressBar
-            key={2}
-            variant="success"
-            label={rightLabel}
-            now={this.rightValue}
-          />
-        </ProgressBar>
+        <div className="progress-container" ref={this.progressRef}>
+          <ProgressBar onClick={this.handleClick}>
+            <ProgressBar
+              key={1}
+              variant="warning"
+              label={leftLabel}
+              now={this.leftValue}
+            />
+            <ProgressBar
+              key={2}
+              variant="success"
+              label={rightLabel}
+              now={this.rightValue}
+            />
+          </ProgressBar>
+        </div>
         <FormControl
           name="left"
           value={this.leftValue}

--- a/src/components/SplitSlider/SplitSlider.js
+++ b/src/components/SplitSlider/SplitSlider.js
@@ -19,11 +19,16 @@ export default class SplitSlider extends Component {
   constructor(props) {
     super(props);
 
-    this.state = { value: 50 };
     this.progressRef = React.createRef();
+    this.state = { value: 50, dragging: false };
+    this.emptyCanvas = document.createElement('canvas');
+    this.handleDrag = this.handleDrag.bind(this);
     this.handleClick = this.handleClick.bind(this);
     this.handleReset = this.handleReset.bind(this);
     this.handleChange = this.handleChange.bind(this);
+    this.handleDragEnd = this.handleDragEnd.bind(this);
+    this.handleDragEnter = this.handleDragEnter.bind(this);
+    this.handleDragStart = this.handleDragStart.bind(this);
   }
 
   get leftValue() {
@@ -76,13 +81,56 @@ export default class SplitSlider extends Component {
     });
   }
 
+  handleDragStart(event) {
+    event.dataTransfer.setDragImage(this.emptyCanvas, 0, 0);
+    event.persist();
+    this.setState(
+      {
+        dragging: true
+      },
+      () => {
+        this.handleClick(event);
+      }
+    );
+  }
+
+  handleDrag(event) {
+    const { dragging } = this.state;
+
+    if (!dragging) {
+      return;
+    }
+
+    event.persist();
+    this.handleClick(event);
+  }
+
+  handleDragEnter(event) {
+    event.dataTransfer.dropEffect = 'move';
+  }
+
+  handleDragEnd(event) {
+    event.persist();
+    this.handleClick(event);
+    this.setState({
+      dragging: false
+    });
+  }
+
   render() {
     const { leftLabel, rightLabel } = this.props;
 
     return (
       <InputGroup className="split-slider">
         <div className="progress-container" ref={this.progressRef}>
-          <ProgressBar onClick={this.handleClick}>
+          <ProgressBar
+            draggable
+            onClick={this.handleClick}
+            onDrag={this.handleDrag}
+            onDragEnd={this.handleDragEnd}
+            onDragStart={this.handleDragStart}
+            onDragEnter={this.handleDragEnter}
+          >
             <ProgressBar
               key={1}
               variant="success"

--- a/src/components/SplitSlider/SplitSlider.scss
+++ b/src/components/SplitSlider/SplitSlider.scss
@@ -3,10 +3,24 @@
     cursor: pointer;
     height: 100%;
     width: 100%;
+    border: 1px solid $black;
+    border-right: none;
+    border-radius: 0.25rem;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
 
     &-container {
       height: auto;
       width: 70%;
     }
+
+    .progress-bar:not(:last-child) {
+      border-right: 1px solid $black;
+    }
+  }
+
+  .btn {
+    height: 100%;
+    padding: 0 5px;
   }
 }

--- a/src/components/SplitSlider/SplitSlider.scss
+++ b/src/components/SplitSlider/SplitSlider.scss
@@ -1,6 +1,12 @@
 .split-slider {
   .progress {
-    height: auto;
-    width: 80%;
+    cursor: pointer;
+    height: 100%;
+    width: 100%;
+
+    &-container {
+      height: auto;
+      width: 70%;
+    }
   }
 }

--- a/src/components/SplitSlider/SplitSlider.scss
+++ b/src/components/SplitSlider/SplitSlider.scss
@@ -1,6 +1,6 @@
 .split-slider {
   .progress {
-    cursor: pointer;
+    cursor: col-resize;
     height: 100%;
     width: 100%;
     border: 1px solid $black;
@@ -8,6 +8,7 @@
     border-radius: 0.25rem;
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
+    user-select: none;
 
     &-container {
       height: auto;

--- a/src/components/SplitSlider/SplitSlider.scss
+++ b/src/components/SplitSlider/SplitSlider.scss
@@ -1,0 +1,6 @@
+.split-slider {
+  .progress {
+    height: auto;
+    width: 80%;
+  }
+}

--- a/src/components/SplitSlider/SplitSlider.scss
+++ b/src/components/SplitSlider/SplitSlider.scss
@@ -24,4 +24,8 @@
     height: 100%;
     padding: 0 5px;
   }
+
+  .form-control {
+    padding: 6px;
+  }
 }

--- a/src/components/SplitSlider/SplitSlider.test.js
+++ b/src/components/SplitSlider/SplitSlider.test.js
@@ -5,7 +5,7 @@ import SplitSlider from './SplitSlider';
 
 describe('<SplitSlider />', () => {
   it('renders component correctly', () => {
-    const tree = renderer.create(<SplitSlider />).toJSON();
+    const tree = renderer.create(<SplitSlider initialValue={50} />).toJSON();
 
     expect(tree).toMatchSnapshot();
   });

--- a/src/components/SplitSlider/SplitSlider.test.js
+++ b/src/components/SplitSlider/SplitSlider.test.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import SplitSlider from './SplitSlider';
+
+describe('<SplitSlider />', () => {
+  it('renders component correctly', () => {
+    const tree = renderer.create(<SplitSlider />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/SplitSlider/SplitSlider.test.js
+++ b/src/components/SplitSlider/SplitSlider.test.js
@@ -5,7 +5,11 @@ import SplitSlider from './SplitSlider';
 
 describe('<SplitSlider />', () => {
   it('renders component correctly', () => {
-    const tree = renderer.create(<SplitSlider initialValue={50} />).toJSON();
+    const tree = renderer
+      .create(
+        <SplitSlider name="test" initialValue={50} onChange={jest.fn()} />
+      )
+      .toJSON();
 
     expect(tree).toMatchSnapshot();
   });

--- a/src/components/SplitSlider/__snapshots__/SplitSlider.test.js.snap
+++ b/src/components/SplitSlider/__snapshots__/SplitSlider.test.js.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SplitSlider /> renders component correctly 1`] = `
+<div
+  className="split-slider input-group"
+>
+  <div
+    className="progress-container"
+  >
+    <div
+      className="progress"
+      onClick={[Function]}
+    >
+      <div
+        aria-valuemax={100}
+        aria-valuemin={0}
+        aria-valuenow={50}
+        className="progress-bar bg-success"
+        role="progressbar"
+        style={
+          Object {
+            "width": "50%",
+          }
+        }
+      >
+        VG
+      </div>
+      <div
+        aria-valuemax={100}
+        aria-valuemin={0}
+        aria-valuenow={50}
+        className="progress-bar bg-warning"
+        role="progressbar"
+        style={
+          Object {
+            "width": "50%",
+          }
+        }
+      >
+        PG
+      </div>
+    </div>
+  </div>
+  <input
+    className="form-control"
+    name="left"
+    onChange={[Function]}
+    value={50}
+  />
+  <input
+    className="form-control"
+    name="right"
+    onChange={[Function]}
+    value={50}
+  />
+</div>
+`;

--- a/src/components/SplitSlider/__snapshots__/SplitSlider.test.js.snap
+++ b/src/components/SplitSlider/__snapshots__/SplitSlider.test.js.snap
@@ -9,7 +9,13 @@ exports[`<SplitSlider /> renders component correctly 1`] = `
   >
     <div
       className="progress"
+      draggable={true}
       onClick={[Function]}
+      onDrag={[Function]}
+      onDragEnd={[Function]}
+      onDragEnter={[Function]}
+      onDragOver={[Function]}
+      onDragStart={[Function]}
     >
       <div
         aria-valuemax={100}

--- a/src/components/SplitSlider/__snapshots__/SplitSlider.test.js.snap
+++ b/src/components/SplitSlider/__snapshots__/SplitSlider.test.js.snap
@@ -53,5 +53,19 @@ exports[`<SplitSlider /> renders component correctly 1`] = `
     onChange={[Function]}
     value={50}
   />
+  <div
+    className="input-group-append"
+  >
+    <button
+      className="btn btn-primary"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      <i
+        className="fa undo"
+      />
+    </button>
+  </div>
 </div>
 `;

--- a/src/icons.js
+++ b/src/icons.js
@@ -5,7 +5,8 @@ import {
   faHeart as fasHeart,
   faStar as fasStar,
   faCheck,
-  faTimesCircle
+  faTimesCircle,
+  faUndo
 } from '@fortawesome/free-solid-svg-icons';
 import {
   faHeart as farHeart,
@@ -24,7 +25,8 @@ library.add(
   fasStar,
   farStar,
   faCheckSquare,
-  faSquare
+  faSquare,
+  faUndo
 );
 
 export default library;

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,5 +1,7 @@
 @import "~normalize-scss/sass/normalize/import-now";
 @import "~bootstrap/scss/bootstrap";
 @import "./components/ToastDrawer/ToastDrawer";
+
+@import "./components/SplitSlider/SplitSlider";
 @import "./components/SuspenseFallback/SuspenseFallback";
 @import "./style.scss";


### PR DESCRIPTION
This PR adds a SplitSlider component which will be used for VG/PG ratio and similar settings.

It takes tickInterval, leftLabel, rightLabel, initialValue, onChange, and name props.

It looks like this:

![thing](https://user-images.githubusercontent.com/266545/74487385-56b0bd00-4e8d-11ea-8fd0-37442548edd2.PNG)

You can click and drag on it to change its value or type in either one of the attached input fields. You can click the "undo" icon to reset the control to 50/50. 