### PR TITLE
Get anonymous auth working

### DIFF
--- a/src/components/Pagination/Pagination.js
+++ b/src/components/Pagination/Pagination.js
@@ -66,7 +66,7 @@ export const pagination = WrappedComponent =>
 
     navigation() {
       return (
-        <Container fluid={true}>
+        <Container fluid>
           <Row className="pb-2">
             <Col xs={3}>
               <input
@@ -146,7 +146,7 @@ export class PagerInfo extends Component {
     } = this.props;
 
     return (
-      <Container fluid={true}>
+      <Container fluid>
         <Row>
           <Col>
             {count} {contentType}

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -100,7 +100,7 @@ class Request {
     });
 
     if (!response) {
-      return failureMessage('Request timed out!');
+      return { message: 'Request timed out!' };
     }
 
     return response;

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -49,31 +49,28 @@ class Request {
     this.execute = this.execute.bind(this);
   }
 
-  isUrlProtected(url) {
-    const unprotectedResources = ['oauth', 'register'];
+  /**
+   * Return an access token if available.
+   */
+  *getAccessToken() {
+    const authInfo = yield select(getAuthorization);
 
-    for (const resource of unprotectedResources) {
-      if (url.startsWith(`/${resource}`)) {
-        return false;
-      }
+    if (!authInfo) {
+      return null;
     }
 
-    return true;
+    const { accessToken, expiration } = authInfo;
+    const validToken = accessToken && dayjs().isBefore(expiration);
+
+    return validToken ? accessToken : null;
   }
 
   /**
-   * Fetches an access token or returns from the store if present
+   * Wait for an access token to be successfully requested.
    *
-   * @param {Number} timeout
+   * @param {number} timeout Number of milliseconds to wait for user to login
    */
-  *getAccessToken(timeout) {
-    const { accessToken, expiration } = yield select(getAuthorization);
-
-    // sanity check authorization information
-    if (accessToken && dayjs().isBefore(expiration)) {
-      return accessToken;
-    }
-
+  *waitForAccessToken(timeout) {
     try {
       const { authorization } = yield race({
         authorization: take(types.REQUEST_TOKEN_SUCCESS),
@@ -90,7 +87,26 @@ class Request {
     }
   }
 
-  *execute({ endpoint, data, headers, options = {} }) {
+  *makeRequest(url, method, data, headers, timeout) {
+    // start a race between the request and a timer, cancel the loser
+    const { response } = yield race({
+      response: call(axios, {
+        url,
+        method,
+        data,
+        headers
+      }),
+      timeout: delay(timeout)
+    });
+
+    if (!response) {
+      return failureMessage('Request timed out!');
+    }
+
+    return response;
+  }
+
+  *execute({ endpoint, data, headers = {}, options = {} }) {
     try {
       // ensure the endpoint was supplied
       if (!endpoint) {
@@ -108,39 +124,41 @@ class Request {
         return failureMessage('Endpoint is missing method!');
       }
 
-      // default timeout of 10 seconds
+      // default request timeout of 10 seconds
       const { timeout = 10000 } = options;
 
-      if (this.isUrlProtected(url)) {
-        const accessToken = yield* this.getAccessToken(timeout);
+      // build the request URL
+      const requestUrl = yield call(buildUrl, endpoint);
 
-        if (!accessToken) {
-          return failureMessage('Missing authorization information!');
-        }
+      let accessToken = yield* this.getAccessToken();
 
-        // destructured parameters are declared as var
-        if (!headers) {
-          headers = {};
-        }
-
+      if (accessToken) {
         headers.Authorization = `Bearer ${accessToken}`;
       }
 
-      const requestUrl = yield call(buildUrl, endpoint);
+      let response = yield* this.makeRequest(
+        requestUrl,
+        method,
+        data,
+        headers,
+        timeout
+      );
 
-      // start a race between the request and a timer, cancel the loser
-      const { response } = yield race({
-        response: call(axios, {
-          url: requestUrl,
-          headers,
-          method,
-          data
-        }),
-        timeout: delay(timeout)
-      });
+      if (!accessToken && response.status === 403) {
+        accessToken = yield* this.waitForAccessToken(timeout);
 
-      if (!response) {
-        return failureMessage('Request timed out!');
+        if (!accessToken) {
+          return failureMessage('Unable to obtain required token!');
+        } else {
+          headers.Authorization = `Bearer ${accessToken}`;
+          response = yield* this.makeRequest(
+            requestUrl,
+            method,
+            data,
+            headers,
+            timeout
+          );
+        }
       }
 
       const { status } = response;


### PR DESCRIPTION
Implement changes to the request module that allow anonymous requests to succeed where they would fail before. If a bearer token is available, it will be used in the request. If that request fails with an HTTP 403, then the existing behavior of waiting for a login will be used.

 * [Remove](https://github.com/mixnjuice/frontend/compare/master...ayan4m1:feature/auth-overhaul?expand=1#diff-65648bcf997c5be8e245199eb59c69b7R69) some instances of a superfluous `prop={true}`
 * [Remove](https://github.com/mixnjuice/frontend/compare/master...ayan4m1:feature/auth-overhaul?expand=1#diff-24dbc3ca3b4db4e46b1194dc68247a70L52) the isUrlProtected method
 * [Change](https://github.com/mixnjuice/frontend/compare/master...ayan4m1:feature/auth-overhaul?expand=1#diff-24dbc3ca3b4db4e46b1194dc68247a70R55) getAccessToken to return a token or not, but never wait for login
 * [Add](https://github.com/mixnjuice/frontend/compare/master...ayan4m1:feature/auth-overhaul?expand=1#diff-24dbc3ca3b4db4e46b1194dc68247a70R73) waitForAccessToken to encapsulate existing "wait for login" behavior
 * [Add](https://github.com/mixnjuice/frontend/compare/master...ayan4m1:feature/auth-overhaul?expand=1#diff-24dbc3ca3b4db4e46b1194dc68247a70R90) makeRequest helper
 * [Overhaul](https://github.com/mixnjuice/frontend/compare/master...ayan4m1:feature/auth-overhaul?expand=1#diff-24dbc3ca3b4db4e46b1194dc68247a70L114) execute method implementation with new logic
 * [Update](https://github.com/mixnjuice/frontend/compare/master...ayan4m1:feature/auth-overhaul?expand=1#diff-4b477d47677c5f7e508f1a5f9232b447) related test cases and clean up duplicate code in test