### PR TITLE
Set max-width for Pager Elements

### DIFF
--- a/src/components/Pagination/Pagination.scss
+++ b/src/components/Pagination/Pagination.scss
@@ -1,12 +1,14 @@
 .pager {
   &-limit {
     display: inline;
-    width: 80px;
+    width: unset;
+    max-width: 80px;
   }
 
   &-page {
     display: inline;
-    width: 80px;
+    width: unset;
+    max-width: 80px;
     margin: 0 8px;
   }
 

--- a/src/components/Pagination/Pagination.scss
+++ b/src/components/Pagination/Pagination.scss
@@ -1,12 +1,12 @@
 .pager {
   &-limit {
     display: inline;
-    width: unset;
+    width: 80px;
   }
 
   &-page {
     display: inline;
-    width: unset;
+    width: 80px;
     margin: 0 8px;
   }
 


### PR DESCRIPTION
Fixes an issue where Firefox ignores a width property for inline elements unless it sets a length value:

https://developer.mozilla.org/en-US/docs/Web/CSS/width