### PR TITLE
Fix broken tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16403,9 +16403,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.9.tgz",
-      "integrity": "sha512-fFiXlFo4Wkuei3i6w9SQI6yuzGRTGi8Z2zZKZpUxv/bQlBi4jtbVPBSNFZHQA9PNjofWqtIa8p+pnsc0kgZrhQ=="
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.10.tgz",
+      "integrity": "sha512-iZFMXKeXWkxzlfmMfM91gw7YhN2sdJtixY+eZh9V6QWJWTOiurhpKhBMgr82pfzgSqglQgqYSCowEYsz8D++6w=="
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "final-form": "^4.20.0",
     "lodash.debounce": "^4.0.8",
     "lodash.omit": "^4.5.0",
-    "nanoid": "^3.1.9",
+    "nanoid": "^3.1.10",
     "normalize-scss": "^7.0.1",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",

--- a/src/components/Header/__snapshots__/Header.test.js.snap
+++ b/src/components/Header/__snapshots__/Header.test.js.snap
@@ -25,7 +25,7 @@ exports[`<Header /> renders logged in correctly 1`] = `
         <button
           aria-controls="basic-navbar-nav"
           aria-label="Toggle navigation"
-          className="navbar-toggler"
+          className="navbar-toggler collapsed"
           onClick={[Function]}
           type="button"
         >
@@ -48,9 +48,7 @@ exports[`<Header /> renders logged in correctly 1`] = `
               disabled={false}
               href="/"
               onClick={[Function]}
-              role="tab"
               style={Object {}}
-              tabIndex={-1}
             >
               Home
             </a>
@@ -61,8 +59,6 @@ exports[`<Header /> renders logged in correctly 1`] = `
               disabled={false}
               href="/recipes"
               onClick={[Function]}
-              role="tab"
-              tabIndex={-1}
             >
               Recipes
             </a>
@@ -73,8 +69,6 @@ exports[`<Header /> renders logged in correctly 1`] = `
               disabled={false}
               href="/recipe/editor"
               onClick={[Function]}
-              role="tab"
-              tabIndex={-1}
             >
               Recipe Editor
             </a>
@@ -85,8 +79,6 @@ exports[`<Header /> renders logged in correctly 1`] = `
               disabled={false}
               href="/flavors"
               onClick={[Function]}
-              role="tab"
-              tabIndex={-1}
             >
               Flavors
             </a>
@@ -102,96 +94,10 @@ exports[`<Header /> renders logged in correctly 1`] = `
                 href="#"
                 onClick={[Function]}
                 onKeyDown={[Function]}
-                role="tab"
-                tabIndex={-1}
+                role="button"
               >
                 User
               </a>
-              <div
-                className="dropdown-menu"
-              >
-                <a
-                  aria-current={null}
-                  className="nav--link-custom dropdown-item"
-                  disabled={false}
-                  href="/user/profile"
-                  onClick={[Function]}
-                >
-                  Profile
-                  <br />
-                </a>
-                <a
-                  aria-current={null}
-                  className="nav--link-custom dropdown-item"
-                  disabled={false}
-                  href="/user/recipes"
-                  onClick={[Function]}
-                >
-                  Recipes
-                  <br />
-                </a>
-                <a
-                  aria-current={null}
-                  className="nav--link-custom dropdown-item"
-                  disabled={false}
-                  href="/user/favorites"
-                  onClick={[Function]}
-                >
-                  Favorites
-                  <br />
-                </a>
-                <a
-                  aria-current={null}
-                  className="nav--link-custom dropdown-item"
-                  disabled={false}
-                  href="/user/flavor-stash"
-                  onClick={[Function]}
-                >
-                  Flavor Stash
-                  <br />
-                </a>
-                <a
-                  aria-current={null}
-                  className="nav--link-custom dropdown-item"
-                  disabled={false}
-                  href="/user/shopping-list"
-                  onClick={[Function]}
-                >
-                  Shopping List
-                  <br />
-                </a>
-                <a
-                  aria-current={null}
-                  className="nav--link-custom dropdown-item"
-                  disabled={false}
-                  href="/user/settings"
-                  onClick={[Function]}
-                >
-                  Settings
-                  <br />
-                </a>
-                <a
-                  aria-current={null}
-                  className="nav--link-custom dropdown-item"
-                  disabled={false}
-                  href="/dashboard"
-                  onClick={[Function]}
-                >
-                  Dashboard
-                  <br />
-                </a>
-                <a
-                  aria-current="page"
-                  className="nav--link-custom dropdown-item active"
-                  disabled={false}
-                  href="/"
-                  onClick={[Function]}
-                  style={Object {}}
-                >
-                  Logout
-                  <br />
-                </a>
-              </div>
             </div>
           </div>
         </div>
@@ -226,7 +132,7 @@ exports[`<Header /> renders logged out correctly 1`] = `
         <button
           aria-controls="basic-navbar-nav"
           aria-label="Toggle navigation"
-          className="navbar-toggler"
+          className="navbar-toggler collapsed"
           onClick={[Function]}
           type="button"
         >
@@ -249,9 +155,7 @@ exports[`<Header /> renders logged out correctly 1`] = `
               disabled={false}
               href="/"
               onClick={[Function]}
-              role="tab"
               style={Object {}}
-              tabIndex={-1}
             >
               Home
             </a>
@@ -262,8 +166,6 @@ exports[`<Header /> renders logged out correctly 1`] = `
               disabled={false}
               href="/recipes"
               onClick={[Function]}
-              role="tab"
-              tabIndex={-1}
             >
               Recipes
             </a>
@@ -274,8 +176,6 @@ exports[`<Header /> renders logged out correctly 1`] = `
               disabled={false}
               href="/flavors"
               onClick={[Function]}
-              role="tab"
-              tabIndex={-1}
             >
               Flavors
             </a>
@@ -286,8 +186,6 @@ exports[`<Header /> renders logged out correctly 1`] = `
               disabled={false}
               href="/login"
               onClick={[Function]}
-              role="tab"
-              tabIndex={-1}
             >
               Login
             </a>
@@ -298,8 +196,6 @@ exports[`<Header /> renders logged out correctly 1`] = `
               disabled={false}
               href="/register"
               onClick={[Function]}
-              role="tab"
-              tabIndex={-1}
             >
               Register
             </a>

--- a/src/pages/__snapshots__/Register.test.js.snap
+++ b/src/pages/__snapshots__/Register.test.js.snap
@@ -163,7 +163,6 @@ exports[`<Register /> renders connected component correctly 1`] = `
           <label
             className="form-check-label"
             title=""
-            type="checkbox"
           >
             I agree to comply with the Terms of Service
           </label>
@@ -354,7 +353,6 @@ exports[`<Register /> renders correctly 1`] = `
           <label
             className="form-check-label"
             title=""
-            type="checkbox"
           >
             I agree to comply with the Terms of Service
           </label>

--- a/src/sagas/toast.test.js
+++ b/src/sagas/toast.test.js
@@ -3,7 +3,9 @@ import { all, put, delay, takeEvery } from 'redux-saga/effects';
 import { actions, types } from 'reducers/toast';
 import toastSaga, { workers, watchers } from 'sagas/toast';
 
-jest.mock('nanoid', () => () => 'testing');
+jest.mock('nanoid', () => ({
+  nanoid: jest.fn(() => 'testing')
+}));
 
 describe('toast sagas', () => {
   it('runs popToastWorker', () => {


### PR DESCRIPTION
This PR fixes tests that were broken by #78:

 * Update nanoid to fix an ES module bug in it
 * Fix mocked nanoid to match the 3.x export style
 * Update snapshots that broke as a result of react-bootstrap/bootstrap changes