### PR TITLE
Add "pre-mixed base" to recipe editor

### DIFF
--- a/src/pages/RecipeEditor.js
+++ b/src/pages/RecipeEditor.js
@@ -97,7 +97,7 @@ export class RecipeEditor extends Component {
   handleUserInput(event) {
     const { actions } = this.props;
     const {
-      target: { name, value }
+      target: { name, value, checked }
     } = event;
 
     switch (name) {
@@ -105,7 +105,7 @@ export class RecipeEditor extends Component {
         actions.setRecipeName(value);
         break;
       case 'usePreMixedBase':
-        actions.setUsePreMixedBase(value === 'on');
+        actions.setUsePreMixedBase(checked);
         break;
       case 'desiredVolume': {
         const volume = parseInt(value, 10);
@@ -449,6 +449,7 @@ export class RecipeEditor extends Component {
                     <Form.Group as={Col} md="8" controlId="">
                       <Form.Label>Use pre-mixed base</Form.Label>
                       <Form.Check
+                        type="checkbox"
                         name="usePreMixedBase"
                         onChange={this.handleUserInput}
                       />

--- a/src/pages/RecipeEditor.js
+++ b/src/pages/RecipeEditor.js
@@ -26,7 +26,8 @@ import {
   getDesiredNicotineStrength,
   getDesiredVolume,
   getNicotineDiluentRatio,
-  getDesiredDiluentRatio
+  getDesiredDiluentRatio,
+  getUsePreMixedBase
 } from 'selectors/recipe';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
@@ -38,7 +39,8 @@ export class RecipeEditor extends Component {
       setNicotineStrength: PropTypes.func.isRequired,
       setDesiredDiluentRatio: PropTypes.func.isRequired,
       setNicotineDiluentRatio: PropTypes.func.isRequired,
-      setDesiredNicotineStrength: PropTypes.func.isRequired
+      setDesiredNicotineStrength: PropTypes.func.isRequired,
+      setUsePreMixedBase: PropTypes.func.isRequired
     }).isRequired,
     recipe: PropTypes.shape({
       id: PropTypes.string,
@@ -47,10 +49,11 @@ export class RecipeEditor extends Component {
       percentages: PropTypes.arrayOf(PropTypes.object).isRequired
     }),
     nicotineStrength: PropTypes.number.isRequired,
-    desiredNicotineStrength: PropTypes.number.isRequired,
+    desiredNicotineStrength: PropTypes.number,
     desiredVolume: PropTypes.number.isRequired,
-    desiredDiluentRatio: PropTypes.number.isRequired,
-    nicotineDiluentRatio: PropTypes.number.isRequired
+    desiredDiluentRatio: PropTypes.number,
+    nicotineDiluentRatio: PropTypes.number.isRequired,
+    usePreMixedBase: PropTypes.bool.isRequired
   };
 
   constructor(props) {
@@ -100,6 +103,9 @@ export class RecipeEditor extends Component {
     switch (name) {
       case 'name':
         actions.setRecipeName(value);
+        break;
+      case 'usePreMixedBase':
+        actions.setUsePreMixedBase(value === 'on');
         break;
       case 'desiredVolume': {
         const volume = parseInt(value, 10);
@@ -174,42 +180,54 @@ export class RecipeEditor extends Component {
       nicotineStrength,
       desiredDiluentRatio,
       nicotineDiluentRatio,
-      recipe: { percentages }
+      recipe: { percentages },
+      usePreMixedBase
     } = this.props;
 
     let flavorPercent = 0;
 
-    if (percentages.length > 0) {
-      flavorPercent = percentages.reduce((acc, curr) => {
-        return acc + curr.millipercent / 100;
+    const percentageEntries = Object.entries(percentages);
+
+    if (percentageEntries.length > 0) {
+      flavorPercent = percentageEntries.reduce((acc, [, curr]) => {
+        return acc + curr / 100;
       }, 0);
     }
 
-    // determine how many mg of nicotine we need
-    const nicotineMg = desiredNicotineStrength * desiredVolume;
-    // determine how many mL of nicotine base we need
-    const baseNicotineMl = nicotineMg / nicotineStrength;
-    // calculate the percentage of the final mix that will be nicotine
-    const nicotinePercent = baseNicotineMl / desiredVolume;
-    // determine how much of that is VG
-    const nicotineVgPercent = nicotinePercent * nicotineDiluentRatio;
-    const nicotinePgPercent = nicotinePercent * (1 - nicotineDiluentRatio);
-    // figure out the remaining amounts of VG and PG
-    const remainingVgPercent = desiredDiluentRatio - nicotineVgPercent;
-    const remainingPgPercent =
-      1 - desiredDiluentRatio - flavorPercent - nicotinePgPercent;
+    if (!usePreMixedBase) {
+      // determine how many mg of nicotine we need
+      const nicotineMg = desiredNicotineStrength * desiredVolume;
+      // determine how many mL of nicotine base we need
+      const baseNicotineMl = nicotineMg / nicotineStrength;
+      // calculate the percentage of the final mix that will be nicotine
+      const nicotinePercent = baseNicotineMl / desiredVolume;
+      // determine how much of that is VG
+      const nicotineVgPercent = nicotinePercent * nicotineDiluentRatio;
+      const nicotinePgPercent = nicotinePercent * (1 - nicotineDiluentRatio);
+      // figure out the remaining amounts of VG and PG
+      const remainingVgPercent = desiredDiluentRatio - nicotineVgPercent;
+      const remainingPgPercent =
+        1 - desiredDiluentRatio - flavorPercent - nicotinePgPercent;
 
-    // return false if there is too much flavor
-    if (remainingVgPercent < 0 || remainingPgPercent < 0) {
-      return false;
+      // return false if there is too much flavor
+      if (remainingVgPercent < 0 || remainingPgPercent < 0) {
+        return false;
+      }
+
+      return {
+        nicotine: nicotinePercent * 100,
+        flavor: flavorPercent * 100,
+        vg: remainingVgPercent * 100,
+        pg: remainingPgPercent * 100
+      };
+    } else {
+      return {
+        nicotine: (1 - flavorPercent) * 100,
+        flavor: flavorPercent * 100,
+        vg: 0,
+        pg: 0
+      };
     }
-
-    return {
-      nicotine: nicotinePercent * 100,
-      flavor: flavorPercent * 100,
-      vg: remainingVgPercent * 100,
-      pg: remainingPgPercent * 100
-    };
   }
 
   get components() {
@@ -219,7 +237,8 @@ export class RecipeEditor extends Component {
       nicotineStrength,
       desiredNicotineStrength,
       nicotineDiluentRatio,
-      recipe: { ingredients, percentages: ingredientPercentages }
+      recipe: { ingredients, percentages: ingredientPercentages },
+      usePreMixedBase
     } = this.props;
 
     if (!percentages) {
@@ -239,42 +258,71 @@ export class RecipeEditor extends Component {
     const nicotineDensity =
       (1 - nicotineDiluentRatio) * densities.pgNic +
       nicotineDiluentRatio * densities.vgNic;
-    // determine how many mg of nicotine we need
-    const nicotineMg = desiredNicotineStrength * desiredVolume;
-    // determine how many mL of nicotine base we need
-    const nicotineMl = nicotineMg / nicotineStrength;
-    const nicotineGrams = nicotineMl * nicotineDensity;
-    const vgMl = (percentages.vg / 100) * desiredVolume;
-    const vgGrams = vgMl * densities.vg;
-    const pgMl = (percentages.pg / 100) * desiredVolume;
-    const pgGrams = pgMl * densities.pg;
 
-    result.push({
-      name: `${nicotineStrength} mg/mL nicotine`,
-      density: nicotineDensity,
-      percentage: percentages.nicotine,
-      milliliters: nicotineMl,
-      grams: nicotineGrams
-    });
+    if (!usePreMixedBase) {
+      // determine how many mg of nicotine we need
+      const nicotineMg = desiredNicotineStrength * desiredVolume;
+      // determine how many mL of nicotine base we need
+      const nicotineMl = nicotineMg / nicotineStrength;
+      const nicotineGrams = nicotineMl * nicotineDensity;
+      const vgMl = (percentages.vg / 100) * desiredVolume;
+      const vgGrams = vgMl * densities.vg;
+      const pgMl = (percentages.pg / 100) * desiredVolume;
+      const pgGrams = pgMl * densities.pg;
 
-    result.push({
-      name: 'Vegetable glycerin',
-      density: densities.vg,
-      percentage: percentages.vg,
-      milliliters: vgMl,
-      grams: vgGrams
-    });
+      result.push({
+        name: `${nicotineStrength} mg/mL nicotine`,
+        density: nicotineDensity,
+        percentage: percentages.nicotine,
+        milliliters: nicotineMl,
+        grams: nicotineGrams
+      });
 
-    result.push({
-      name: 'Propylene glycol',
-      density: densities.pg,
-      percentage: percentages.pg,
-      milliliters: pgMl,
-      grams: pgGrams
-    });
+      result.push({
+        name: 'Vegetable glycerin',
+        density: densities.vg,
+        percentage: percentages.vg,
+        milliliters: vgMl,
+        grams: vgGrams
+      });
+
+      result.push({
+        name: 'Propylene glycol',
+        density: densities.pg,
+        percentage: percentages.pg,
+        milliliters: pgMl,
+        grams: pgGrams
+      });
+    } else {
+      let flavorPercent = 0;
+
+      if (percentageEntries.length > 0) {
+        flavorPercent = percentageEntries.reduce((acc, [, curr]) => {
+          return acc + curr / 100;
+        }, 0);
+      }
+
+      const basePercent = 1 - flavorPercent;
+      const nicotineMl = desiredVolume * basePercent;
+      const nicotineGrams = nicotineMl * nicotineDensity;
+
+      result.push({
+        name: `${nicotineStrength} mg/mL nicotine base`,
+        density: nicotineDensity,
+        percentage: basePercent * 100,
+        milliliters: nicotineMl,
+        grams: nicotineGrams
+      });
+    }
 
     for (const [id, percentage] of percentageEntries) {
       const ingredient = ingredients.find((ing) => ing.Flavor.id === id);
+
+      if (!ingredient) {
+        // eslint-disable-next-line
+        continue;
+      }
+
       const name = `${ingredient.Flavor.Vendor.name} ${ingredient.Flavor.name}`;
       const milliliters = (percentage / 100) * desiredVolume;
       const grams = milliliters * densities.pg;
@@ -322,7 +370,8 @@ export class RecipeEditor extends Component {
       nicotineStrength,
       nicotineDiluentRatio,
       desiredDiluentRatio,
-      recipe: { percentages: ingredientPercentages }
+      recipe: { percentages: ingredientPercentages },
+      usePreMixedBase
     } = this.props;
     const { collapsed } = this.state;
     const { percentages, components } = this;
@@ -397,6 +446,13 @@ export class RecipeEditor extends Component {
                         </Form.Control.Feedback>
                       </InputGroup>
                     </Form.Group>
+                    <Form.Group as={Col} md="8" controlId="">
+                      <Form.Label>Use pre-mixed base</Form.Label>
+                      <Form.Check
+                        name="usePreMixedBase"
+                        onChange={this.handleUserInput}
+                      />
+                    </Form.Group>
                   </Form.Row>
                   <Form.Row>
                     <Form.Group as={Col} md="4" controlId="nicotineStrength">
@@ -426,38 +482,40 @@ export class RecipeEditor extends Component {
                       />
                     </Form.Group>
                   </Form.Row>
-                  <Form.Row>
-                    <Form.Group
-                      as={Col}
-                      md="4"
-                      controlId="desiredNicotineStrength"
-                    >
-                      <Form.Label>Desired Strength</Form.Label>
-                      <InputGroup>
-                        <Form.Control
-                          name="desiredNicotineStrength"
-                          type="number"
-                          value={desiredNicotineStrength}
+                  {!usePreMixedBase && (
+                    <Form.Row>
+                      <Form.Group
+                        as={Col}
+                        md="4"
+                        controlId="desiredNicotineStrength"
+                      >
+                        <Form.Label>Desired Strength</Form.Label>
+                        <InputGroup>
+                          <Form.Control
+                            name="desiredNicotineStrength"
+                            type="number"
+                            value={desiredNicotineStrength}
+                            onChange={this.handleUserInput}
+                            placeholder="0"
+                            required
+                          />
+                          <InputGroup.Append>
+                            <InputGroup.Text id="amount-unit">
+                              mg/mL
+                            </InputGroup.Text>
+                          </InputGroup.Append>
+                        </InputGroup>
+                      </Form.Group>
+                      <Form.Group as={Col} md="8">
+                        <Form.Label>Desired VG/PG ratio</Form.Label>
+                        <SplitSlider
+                          name="desiredDiluentRatio"
+                          initialValue={desiredDiluentRatio * 100}
                           onChange={this.handleUserInput}
-                          placeholder="0"
-                          required
                         />
-                        <InputGroup.Append>
-                          <InputGroup.Text id="amount-unit">
-                            mg/mL
-                          </InputGroup.Text>
-                        </InputGroup.Append>
-                      </InputGroup>
-                    </Form.Group>
-                    <Form.Group as={Col} md="8">
-                      <Form.Label>Desired VG/PG ratio</Form.Label>
-                      <SplitSlider
-                        name="desiredDiluentRatio"
-                        initialValue={desiredDiluentRatio * 100}
-                        onChange={this.handleUserInput}
-                      />
-                    </Form.Group>
-                  </Form.Row>
+                      </Form.Group>
+                    </Form.Row>
+                  )}
                 </Col>
                 <Col md="6">
                   <Container>
@@ -524,7 +582,8 @@ const mapStateToProps = (state) => ({
   desiredNicotineStrength: getDesiredNicotineStrength(state),
   desiredVolume: getDesiredVolume(state),
   nicotineDiluentRatio: getNicotineDiluentRatio(state),
-  desiredDiluentRatio: getDesiredDiluentRatio(state)
+  desiredDiluentRatio: getDesiredDiluentRatio(state),
+  usePreMixedBase: getUsePreMixedBase(state)
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/reducers/recipe.js
+++ b/src/reducers/recipe.js
@@ -23,7 +23,8 @@ export const types = buildActions('recipe', [
   'SET_NICOTINE_DILUENT_RATIO',
   'SET_RECIPE_NAME',
   'SET_RECIPE_INGREDIENTS',
-  'SET_RECIPE_PERCENTAGES'
+  'SET_RECIPE_PERCENTAGES',
+  'SET_USE_PRE_MIXED_BASE'
 ]);
 
 const createRecipe = () => ({
@@ -134,6 +135,11 @@ const setRecipePercentages = (percentages) => ({
   percentages
 });
 
+const setUsePreMixedBase = (usePreMixedBase) => ({
+  type: types.SET_USE_PRE_MIXED_BASE,
+  usePreMixedBase
+});
+
 export const actions = {
   createRecipe,
   createRecipeSuccess,
@@ -157,7 +163,8 @@ export const actions = {
   setNicotineDiluentRatio,
   setRecipeName,
   setRecipeIngredients,
-  setRecipePercentages
+  setRecipePercentages,
+  setUsePreMixedBase
 };
 
 export const initialState = {
@@ -177,7 +184,8 @@ export const initialState = {
   },
   settings: {
     nicotineStrength: 100,
-    nicotineDiluentRatio: 1
+    nicotineDiluentRatio: 1,
+    usePreMixedBase: false
   }
 };
 
@@ -290,6 +298,14 @@ export const reducer = (state = initialState, action = {}) => {
         active: {
           ...state.active,
           percentages: action.percentages
+        }
+      };
+    case types.SET_USE_PRE_MIXED_BASE:
+      return {
+        ...state,
+        settings: {
+          ...state.settings,
+          usePreMixedBase: action.usePreMixedBase
         }
       };
     default:

--- a/src/selectors/recipe.js
+++ b/src/selectors/recipe.js
@@ -69,3 +69,8 @@ export const getDesiredVolume = createSelector(
   getDesired,
   (desired) => desired.volume
 );
+
+export const getUsePreMixedBase = createSelector(
+  getSettings,
+  (settings) => settings.usePreMixedBase
+);


### PR DESCRIPTION
This PR adds a `usePreMixedBase` boolean to the recipe settings in Redux. This is then wired up to a checkbox on the Recipe Editor form, which will cause the editor to behave differently if checked. If checked, it assumes one diluent which is pre-mixed nicotine base, updating the calculations and components accordingly.