### PR TITLE
Add API_URL to exported env vars, add .env.default

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -1,0 +1,3 @@
+FRONTEND_HOST=localhost
+FRONTEND_PORT=8080
+API_URL=http://localhost:3000/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,10 @@ services:
     container_name: mixnjuice-frontend
     restart: always
     environment:
-      VIRTUAL_HOST: ${FRONTEND_HOST}
-      VIRTUAL_PORT: ${FRONTEND_PORT}
-      LETSENCRYPT_HOST: ${FRONTEND_HOST}
+      - VIRTUAL_HOST
+      - VIRTUAL_PORT
+      - LETSENCRYPT_HOST
+      - API_URL
     networks:
       - proxy_proxy
 networks:


### PR DESCRIPTION
This PR adds the API_URL environment variable to docker-compose.yml so that it is passed through to the webpack runtime.

I also added a .env.default so that others can quickly get started customizing their environment.