### PR TITLE
Use node LTS version instead of latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     working_directory: ~/mixnjuice-frontend
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:lts
     steps:
       - checkout
       - run:


### PR DESCRIPTION
This PR fixes CircleCI build failures related to using Node 15 which will be resolved if we build the app using Node LTS version instead.